### PR TITLE
More instructions on backtraces

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 A panic hook which logs panics rather than printing them.
 
+## Logging with a backtrace
+
+Because logging with a backtrace requires additional dependencies, the `with-backtrace` feature must be enabled in order to use it. You can add the following in your `Cargo.toml`:
+
+```
+log-panics = { version = "2", features = ["with-backtrace"]}
+```
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@
 
 A panic hook which logs panics rather than printing them.
 
-## Logging with a backtrace
-
-Because logging with a backtrace requires additional dependencies, the `with-backtrace` feature must be enabled in order to use it. You can add the following in your `Cargo.toml`:
-
-```
-log-panics = { version = "2", features = ["with-backtrace"]}
-```
-
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,14 @@
 //! A crate which logs panics instead of writing to standard error.
 //!
-//! The format used is identical to the standard library's. If the
-//! `with-backtrace` Cargo feature is enabled, a backtrace will be printed along
-//! with the panic message.
+//! The format used is identical to the standard library's.
+//!
+//! Because logging with a backtrace requires additional dependencies,
+//! the `with-backtrace` feature must be enabled. You can add the
+//! following in your `Cargo.toml`:
+//!
+//! ```toml
+//! log-panics = { version = "2", features = ["with-backtrace"]}
+//! ```
 #![doc(html_root_url = "https://docs.rs/log-panics/2.0.0")]
 #![warn(missing_docs)]
 


### PR DESCRIPTION
I got confused thinking that there was some relationship to `RUST_BACKTRACE`, so this change spells out pretty explicitly how to enable backtraces.