### PR TITLE
Bump env_logger dependency to 0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ save_registry: &SAVE_REGISTRY
       - ~/.cargo/registry/index
 
 deps_key: &DEPS_KEY
-  key: dependencies-1.18-{{ checksum "Cargo.lock" }}
+  key: dependencies-1.45-{{ checksum "Cargo.lock" }}
 
 restore_deps: &RESTORE_DEPS
   restore_cache:
@@ -20,14 +20,14 @@ save_deps: &SAVE_DEPS
     <<: *DEPS_KEY
     paths:
       - target
-      - ~/.cargo/regisstry/cache
+      - ~/.cargo/registry/cache
 
 version: 2
 jobs:
   build:
     working_directory: ~/build
     docker:
-      - image: jimmycuadra/rust:1.18.0
+      - image: rust:1.45.0
     steps:
       - checkout
       - <<: *RESTORE_REGISTRY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ log = "0.4"
 backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]
-env_logger = "0.5"
+env_logger = "0.7"


### PR DESCRIPTION
Works without any code change:

https://koji.fedoraproject.org/koji/taskinfo?taskID=46288084

```
   Doc-tests log-panics
     Running `/usr/bin/rustdoc --crate-type lib --test /builddir/build/BUILD/log-panics-2.0.0/src/lib.rs --crate-name log_panics -L dependency=/builddir/build/BUILD/log-panics-2.0.0/target/release/deps -L dependency=/builddir/build/BUILD/log-panics-2.0.0/target/release/deps --extern env_logger=/builddir/build/BUILD/log-panics-2.0.0/target/release/deps/libenv_logger-8c3416e891a85a35.rlib --extern log=/builddir/build/BUILD/log-panics-2.0.0/target/release/deps/liblog-cf6b4a0e1628a84c.rlib --extern log_panics=/builddir/build/BUILD/log-panics-2.0.0/target/release/deps/liblog_panics-c3ea93e8275695be.rlib`
```

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfackler/rust-log-panics/6)
<!-- Reviewable:end -->
