### PR TITLE
Improve code quality

### DIFF
--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -1,5 +1,5 @@
-extern crate log_panics;
 extern crate env_logger;
+extern crate log_panics;
 
 fn main() {
     env_logger::init();


### PR DESCRIPTION
i don't think these changes are controversial. rust's standard library uses '<unnamed>', so it's good to be consistent.