### PR TITLE
Enabled support for tracing crate as a non default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [features]
 with-backtrace = ["backtrace"]
-with-tracing = ["tracing]
+with-tracing = ["tracing"]
 with-log = ["log"]
 default = ["with-log"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ readme = "README.md"
 
 [features]
 with-backtrace = ["backtrace"]
+with-tracing = ["tracing]
+with-log = ["log"]
+default = ["with-log"]
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4", optional = true }
+tracing = { version = "0.1", optional = true }
 backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,13 @@
 // Enable feature requirements on docs.rs.
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+#[cfg(all(feature = "with-tracing", feature = "with-log"))]
+compile_error!("features `with-tracing` and `with-log` are mutually exclusive");
+
+#[cfg(feature = "with-tracing")]
+#[macro_use]
+extern crate tracing;
+#[cfg(feature = "with-log")]
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
In our crates, we use tracing as the crate for logging. The rust-log-panics crate doesn't work well in its current state since it uses log crate for logging the panics. Enabled the crate to use macros from the tracing crate on enabling 'with-tracing' feature, and kept the default features to use 'with-log' which uses log crate. Also added a compile error if there is an attempt to use both these features together