### PR TITLE
Bump env_logger dev-dependency to 0.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ save_registry: &SAVE_REGISTRY
       - ~/.cargo/registry/index
 
 deps_key: &DEPS_KEY
-  key: dependencies-1.45-{{ checksum "Cargo.lock" }}
+  key: dependencies-1.71-{{ checksum "Cargo.lock" }}
 
 restore_deps: &RESTORE_DEPS
   restore_cache:
@@ -27,7 +27,7 @@ jobs:
   build:
     working_directory: ~/build
     docker:
-      - image: rust:1.45.0
+      - image: rust:1.71.0
     steps:
       - checkout
       - <<: *RESTORE_REGISTRY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]
-env_logger = "0.7"
+env_logger = "0.11"
 
 [package.metadata."docs.rs"]
 all-features = true


### PR DESCRIPTION
No code changes are needed and the higher MSRV also doesn't affect library users since this is a dev-dependency used only in example code.
